### PR TITLE
Specify transformers version to avoid tensor error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ safetensors
 tqdm
 open_clip_torch
 blip-ci
-transformers==4.26.1
+transformers>=4.15.0,<=4.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ safetensors
 tqdm
 open_clip_torch
 blip-ci
+transformers==4.26.1


### PR DESCRIPTION
Addressing issue #62 -- Currently, Transformers 4.27.X is causing errors. Specify Transformers 4.26.1 to fix.