### PR TITLE
Fix MPS usage via autocast change

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,7 +1,0 @@
-import sys
-from PIL import Image
-from clip_interrogator import Config, Interrogator
-# import torch
-image = Image.open('../pushd-gpt/output/resized.jpg').convert('RGB')
-ci = Interrogator(Config(clip_model_name="ViT-H-14/laion2b_s32b_b79k", device='mps'))
-print(ci.interrogate(image))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import sys
+from PIL import Image
+from clip_interrogator import Config, Interrogator
+# import torch
+image = Image.open('../pushd-gpt/output/resized.jpg').convert('RGB')
+ci = Interrogator(Config(clip_model_name="ViT-H-14/laion2b_s32b_b79k", device='mps'))
+print(ci.interrogate(image))


### PR DESCRIPTION
Hello!

I'm using this on an Apple Silicon device (M1 Max) and noticed that it fails to use MPS. It seems the issue comes from the amp.autocast call, which is hardcoded to CUDA here. While [there is no M1 support for AMP yet](https://github.com/pytorch/pytorch/issues/88415), changing it to use "cpu" in this spot seems to fix it and get torch running on MPS anyways instead of falling back to CPU on Apple Silicon.

Let me know if there's anything else you'd like, if this is of interest to merge! I'm just tinkering at this point and will eventually move to a linux-based production deployment anyways so this isn't _really_ mission-critical.