### PR TITLE
Split model name correctly

### DIFF
--- a/clip_interrogator/clip_interrogator.py
+++ b/clip_interrogator/clip_interrogator.py
@@ -96,7 +96,7 @@ class Interrogator():
         start_time = time.time()
         config = self.config
 
-        clip_model_name, clip_model_pretrained_name = config.clip_model_name.split('/', 2)
+        clip_model_name, clip_model_pretrained_name = config.clip_model_name.split('/', 1)
 
         if config.clip_model is None:
             if not config.quiet:


### PR DESCRIPTION
`String.split(..., 2)` will split the string at most 2 times, resulting in a 3-tuple. Presumably the intent here was to have a 2-tuple at most, meaning the string gets split at most once.